### PR TITLE
Added twxs.cmake as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     },
     "extensionDependencies": [
         "ms-vscode.cpptools",
+        "twxs.cmake",
         "vector-of-bool.cmake-tools"
     ],
     "dependencies": {


### PR DESCRIPTION
This is necessary because cmake-tools no longer supports the setting "cmake.cmakePath".
The reason is that the same setting is already provided by the extension "twxs.cmake".
Currently, both authors are considering whether they want to merge their extensions.
As long as this does not happen, you should add this extension to your dependencies.

By the way, changing the version of cmake doesn't work without this dependency :-)