### PR TITLE
Fixed crash on fileGroups == null

### DIFF
--- a/src/c_cpp_properties.ts
+++ b/src/c_cpp_properties.ts
@@ -26,7 +26,7 @@ export class configuration {
         // collect includes
         const includeDirs = (target => {  // target: CodeModelTarget
             let incDirs: string[] = [];
-            if (target != null) {
+            if (target != null && target.fileGroups != null) {
                 target.fileGroups.forEach(fg => {
                     if (fg.hasOwnProperty('includePath')) {
                         Array.prototype.push.apply(  // concat incDirs and fg's (mapped) array of paths
@@ -42,7 +42,7 @@ export class configuration {
         // collect defines
         const macroDefines = (target => {  // target: CodeModelTarget
             let mDefs: string[] = [];
-            if (target != null) {
+            if (target != null && target.fileGroups != null) {
                 target.fileGroups.forEach(fg => {
                     if (fg.hasOwnProperty('defines')) {
                         Array.prototype.push.apply(mDefs, fg.defines);


### PR DESCRIPTION
Hello,
when I tried to compile some ROS packages cmake-tools-helper crashed due to the fileGroups being undefined. If-ing out this case seems to fix all issues.

~Cheers